### PR TITLE
Add opencode package to NixOS configuration

### DIFF
--- a/modules/nixos/packages.nix
+++ b/modules/nixos/packages.nix
@@ -17,6 +17,7 @@
     lazydocker
     lazygit
     obsidian
+    opencode
     proton-pass
     protonmail-desktop
     protonvpn-gui


### PR DESCRIPTION
## Summary
- include the opencode package in system packages

## Testing
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e61293f3c8326b91e45f6c970af58