### PR TITLE
feat: add codex CLI to NixOS config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,8 @@
     nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
     nvf.url = "github:notashelf/nvf";
     zen-browser.url = "github:0xc000022070/zen-browser-flake";
+    codex.url = "github:Castrozan/codex-flake";
+    codex.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {

--- a/home/anoni.nix
+++ b/home/anoni.nix
@@ -17,6 +17,7 @@
     ../modules/home-manager/zen-browser.nix
     ../modules/home-manager/vscode.nix
     ../modules/home-manager/packages.nix
+    ../modules/home-manager/codex.nix
   ];
 
   home.stateVersion = "25.05";

--- a/modules/home-manager/codex.nix
+++ b/modules/home-manager/codex.nix
@@ -1,0 +1,6 @@
+{ pkgs, inputs, ... }:
+{
+  home.packages = [
+    inputs.codex.packages.${pkgs.system}.default
+  ];
+}


### PR DESCRIPTION
## Summary
- add codex-flake input to flake
- expose codex CLI through home-manager module

## Testing
- `nix flake check` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e620f43708326b78d2ab1d1a8127a